### PR TITLE
Allow use of haml-coffee 1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-haml-coffee",
   "description": "Gulp plugin for haml-coffee",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "homepage": "http://github.com/saschagehlich/gulp-haml-coffee",
   "repository": {
     "type": "git",
@@ -13,10 +13,10 @@
   ],
   "main": "./index.js",
   "dependencies": {
-    "haml-coffee": "~1.14.1",
-    "map-stream": "~0.1.0",
+    "haml-coffee": "^1.14.1",
+    "map-stream": "^0.1.0",
     "plugin-error": "^1.0.1",
-    "replace-ext": "0.0.1"
+    "replace-ext": "^0.0.1"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
1.14 uses optimist, which depends on a vulnerable version of minimist